### PR TITLE
Admin: Adding endpoint for returning student details

### DIFF
--- a/src/main/java/com/example/licenta/controller/AdminController.java
+++ b/src/main/java/com/example/licenta/controller/AdminController.java
@@ -1,18 +1,20 @@
 package com.example.licenta.controller;
 
+import com.example.licenta.exceptions.GeneralAdminException;
 import com.example.licenta.model.User;
+import com.example.licenta.model.dto.StudentStatusDto;
 import com.example.licenta.service.AdminService;
 import com.example.licenta.service.UserService;
 import com.example.licenta.utils.ExcelHelper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+
+import static org.springframework.http.ResponseEntity.notFound;
+import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
 @RequestMapping("/admins")
@@ -45,5 +47,18 @@ public class AdminController {
             }
         }
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Excel file required.");
+    }
+
+    @GetMapping("/students/{studentId}")
+    public ResponseEntity<?> getStudentStatus(@PathVariable Long studentId) {
+        if (studentId <= 0) {
+            notFound();
+        }
+
+        try {
+            return ok(adminService.getStudentStatus(studentId));
+        } catch (GeneralAdminException e) {
+            return new ResponseEntity<>(e.getMessage(), e.getStatus());
+        }
     }
 }

--- a/src/main/java/com/example/licenta/exceptions/GeneralAdminException.java
+++ b/src/main/java/com/example/licenta/exceptions/GeneralAdminException.java
@@ -1,0 +1,15 @@
+package com.example.licenta.exceptions;
+
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+public class GeneralAdminException extends Exception {
+    private String message;
+    private HttpStatus status;
+
+    public GeneralAdminException(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.status = httpStatus;
+    }
+}

--- a/src/main/java/com/example/licenta/model/dto/StudentStatusDto.java
+++ b/src/main/java/com/example/licenta/model/dto/StudentStatusDto.java
@@ -1,0 +1,10 @@
+package com.example.licenta.model.dto;
+
+
+import com.example.licenta.model.SoliciareAcord;
+import com.example.licenta.model.User;
+
+import java.util.List;
+
+public record StudentStatusDto(User user, List<SoliciareAcord> agreementRequests, User coordinator) {
+}

--- a/src/main/java/com/example/licenta/repository/CoordonationRepository.java
+++ b/src/main/java/com/example/licenta/repository/CoordonationRepository.java
@@ -12,4 +12,6 @@ public interface CoordonationRepository extends JpaRepository<Coordonare, Studen
 
     @Query("select c.id.teacherId from Coordonare c where c.id.studentId = :studentId")
     Long findTeacherIdByStudentId(@Param("studentId") Long studentId);
+
+    Coordonare findFirstById_StudentId(Long studentId);
 }

--- a/src/main/java/com/example/licenta/repository/SolicitareAcordRepository.java
+++ b/src/main/java/com/example/licenta/repository/SolicitareAcordRepository.java
@@ -4,6 +4,10 @@ import com.example.licenta.model.SoliciareAcord;
 import com.example.licenta.model.StudentTeacherId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SolicitareAcordRepository extends JpaRepository<SoliciareAcord, StudentTeacherId> {
+
+    List<SoliciareAcord> findAllById_StudentId(Long studentId);
 }
 

--- a/src/main/java/com/example/licenta/service/AdminService.java
+++ b/src/main/java/com/example/licenta/service/AdminService.java
@@ -1,7 +1,13 @@
 package com.example.licenta.service;
 
+import com.example.licenta.exceptions.GeneralAdminException;
 import com.example.licenta.model.User;
+import com.example.licenta.model.dto.StudentStatusDto;
+import com.example.licenta.repository.CoordonationRepository;
+import com.example.licenta.repository.SolicitareAcordRepository;
+import com.example.licenta.repository.UserRepository;
 import com.example.licenta.utils.ExcelHelper;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -11,7 +17,32 @@ import java.util.List;
 @Service
 public class AdminService {
 
+    private final UserRepository userRepository;
+    private final SolicitareAcordRepository solicitareAcordRepository;
+    private final CoordonationRepository coordonationRepository;
+
+    public AdminService(UserRepository userRepository, SolicitareAcordRepository solicitareAcordRepository, CoordonationRepository coordonationRepository) {
+        this.userRepository = userRepository;
+        this.solicitareAcordRepository = solicitareAcordRepository;
+        this.coordonationRepository = coordonationRepository;
+    }
+
     public List<User> processExcel(MultipartFile file) throws IOException {
         return ExcelHelper.excelToUsers(file.getInputStream());
+    }
+
+    public StudentStatusDto getStudentStatus(Long studentId) throws GeneralAdminException {
+        var student = userRepository.findById(studentId).orElseThrow(() -> new GeneralAdminException("Student not found", HttpStatus.NOT_FOUND));
+
+        var agreementRequests = solicitareAcordRepository.findAllById_StudentId(student.getId());
+
+        // In case the student do not have a coordinator, this field will be null
+        var coordinatorId = coordonationRepository.findFirstById_StudentId(student.getId());
+        User coordinator = null;
+        if (coordinatorId != null) {
+            coordinator = userRepository.findById(coordinatorId.getId().getTeacherId()).orElse(null);
+        }
+
+        return new StudentStatusDto(student, agreementRequests, coordinator);
     }
 }


### PR DESCRIPTION
The endpoint includes the current student, the list of agreement requests, and the coordinator. 
In case there is no coordinator the field will be null. 
In case there are no agreement requests, the list will be empty.


A student that has agreement requests and coordinator:
![image](https://user-images.githubusercontent.com/19593839/211418863-33c8e348-77de-425a-a052-782d029bd1e2.png)


A student that does not have agreement requests or a coordinator
![image](https://user-images.githubusercontent.com/19593839/211418957-b259881e-befe-413a-9fde-f5264368da2c.png)


A student that has agreement requests but no coordinator
![image](https://user-images.githubusercontent.com/19593839/211419056-f73c3eea-59dd-47d7-842d-0fcc64bcccd7.png)


